### PR TITLE
fix gcc warning on humble

### DIFF
--- a/robot_controllers/src/diff_drive_base.cpp
+++ b/robot_controllers/src/diff_drive_base.cpp
@@ -307,7 +307,7 @@ void DiffDriveBaseController::update(const rclcpp::Time& now, const rclcpp::Dura
   if (elapsed <= 0.0)
   {
     RCLCPP_WARN(rclcpp::get_logger(getName()),
-                "bad dt = %f", dt);
+                "bad dt = %f", elapsed);
     // use dt = 0.0 as special value, with current code it won't cause
     // issues if it shows up once in a while.
     // however velocities can't change if dt is always zero


### PR DESCRIPTION
[Buildfarm is complaining](https://build.ros2.org/job/Hdev__robot_controllers__ubuntu_jammy_amd64/9/gcc/category.-677443802/category.-677443802/):

```
format ‘%f’ expects argument of type ‘double’, but argument 5 has type ‘const rclcpp::Duration’ [-Wformat=] 310 | "bad dt = %f", dt); | ^~~~~~~~~~~~~
```